### PR TITLE
ovirt - initial seeding to support ovirt

### DIFF
--- a/config/fusor-installer.answers.yaml
+++ b/config/fusor-installer.answers.yaml
@@ -37,7 +37,8 @@ capsule:
   puppetca: true
 
 foreman::plugin::bootdisk: true
-foreman::plugin::discovery: true
+foreman::plugin::discovery:
+  install_images: true
 foreman::plugin::hooks: true
 foreman::plugin::tasks: true
 foreman::plugin::chef: false

--- a/hooks/lib/base_seeder.rb
+++ b/hooks/lib/base_seeder.rb
@@ -43,6 +43,16 @@ class BaseSeeder
                                                              'name' => 'CentOS', 'major' => '7', 'minor' => '0',
                                                              'family' => 'Redhat'}, {})
     end
+
+    # TODO: The creation of OS is currently based upon the OS of the server;
+    # however for our initial scenario (oVirt), we are going to assume that
+    # the hosts that are provisioned are CentOS 6.6.  We'll need to update this
+    # once we have support for the Red Hat content in place
+    # (subscriptions...etc.)
+    additional << foreman.operating_system.show_or_ensure({'id' => 'CentOS 6.6',
+                                                           'name' => 'CentOS', 'major' => '6',
+                                                           'minor' => '6', 'family' => 'Redhat'}, {})
+
     additional
   end
 

--- a/hooks/lib/foreman.rb
+++ b/hooks/lib/foreman.rb
@@ -17,6 +17,7 @@ class Foreman
       :environment => 'Environment',
       :setting => 'Setting',
       :template_combination => 'TemplateCombination',
+      :puppetclass => 'Puppetclass',
   }
 
   def initialize(options)
@@ -83,6 +84,20 @@ class Foreman
         object, _ = @api_resource.show(*args)
       rescue RestClient::ResourceNotFound
         raise StandardError, error_message
+      end
+      object
+    end
+
+    def search_or_ensure(condition, attributes)
+      begin
+        object = first!(condition)
+        if should_update?(object, attributes)
+          identifier = { 'id' => object['id'] }
+          object, _ = @api_resource.update(identifier.merge({@name.to_s => attributes}))
+          object, _ = @api_resource.show(identifier)
+        end
+      rescue StandardError
+        object, _ = @api_resource.create({@name.to_s => attributes})
       end
       object
     end

--- a/hooks/lib/install_modules.sh
+++ b/hooks/lib/install_modules.sh
@@ -1,42 +1,17 @@
 #!/bin/bash
 
 TARGET=/etc/puppet/environments/production/modules/
-OFI_MODULES=/usr/share/openstack-foreman-installer/puppet/modules
-OS_MODULES=/usr/share/openstack-puppet/modules
+OVIRT_MODULE=/usr/share/ovirt-puppet/
 
-if [ -d $OFI_MODULES -a -d $OS_MODULES ]; then
-  # copy modules from packages
-  for mod in "$OFI_MODULES/*"; do
-    ln -nfs $mod $TARGET
-  done
+# TODO: When moving to katello content management, we should instead 
+# install the puppet modules by creating a katello product/repo,
+# uploading modules (tar.gz) to repo, creating/publishing a content view
+# that contains those modules
 
-  for mod in "$OS_MODULES/*"; do
-    ln -nfs $mod $TARGET
-  done
-else
-  # get stable modules for git repositories
-  ASTAPOR_VERSION="origin/1_0_stable"
-  OPENSTACK_MODULES_VERSION="origin/havana"
-  
-  mkdir -p /tmp/foreman_installer_fusor
-  cd /tmp/foreman_installer_fusor
-  rm -rf /tmp/astapor /tmp/openstack-puppet-modules modules
-  mkdir modules
-  
-  echo "Cloning repositories"
-  git clone https://github.com/redhat-openstack/astapor
-  git clone --recursive https://github.com/redhat-openstack/openstack-puppet-modules
-  
-  pushd astapor
-  git reset --hard $ASTAPOR_VERSION
-  popd
-  pushd openstack-puppet-modules
-  git reset --hard $OPENSTACK_MODULES_VERSION
-  popd
-  
-  mv astapor/puppet/modules/* modules
-  mv openstack-puppet-modules/* modules
-  rm -rf astapor openstack-puppet-modules
+# copy modules from the package to the puppet environment
 
-  mv modules/* $TARGET
+if [[ ! -e $TARGET ]]; then
+    mkdir $TARGET
 fi
+
+cp -r $OVIRT_MODULE $TARGET

--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -79,12 +79,10 @@ class ProvisioningSeeder < BaseSeeder
                                             {'id' => 'kickstart_networking_setup'},
                                             {'template' => kickstart_networking_setup_snippet, 'snippet' => '1', 'name' => 'kickstart_networking_setup'})
 
-# TODO: currently commenting out modification of the 'PXELinux global default'.  We'll need to 1. unlock the template, 2. update it to add discovery (vs replace it) and 3. lock the template.  Assuming that Katello is seeding this already and if katello always includes discovery, we may be able to add this to it's seeding instead of doing it here.
-#    name = 'PXELinux global default'
-#    pxe_template = @foreman.config_template.show_or_ensure({'id' => name},
-#                                                           {'template' => template})
-#    default_config_templates << pxe_template
-    pxe_template = nil
+    name = 'PXELinux global default'
+    pxe_template = @foreman.config_template.show_or_ensure({'id' => name},
+                                                           {'template' => template})
+    default_config_templates << pxe_template
 
     @foreman.config_template.build_pxe_default
 


### PR DESCRIPTION
This PR primarily contains changes to seed data needed to support oVirt.

For this first pass, the puppet module is being seeded in to a Foreman puppet environment (production).  Changes will be coming (in a future PR) to utilize Katello content management for this puppet content; however, this was the quickest way to make this functionality available.
