### PR TITLE
installer: use apipie and katello content managment

### DIFF
--- a/fusor-installer.spec
+++ b/fusor-installer.spec
@@ -22,7 +22,6 @@ BuildArch:  noarch
 Requires:   katello-installer
 Requires:   ntp
 Requires:   rubygem-kafo >= 0.6.4
-Requires:   rubygem-foreman_api >= 0.1.4
 Requires:   git
 Requires:   ovirt-puppet
 

--- a/fusor-installer.spec
+++ b/fusor-installer.spec
@@ -26,9 +26,6 @@ Requires:   rubygem-foreman_api >= 0.1.4
 Requires:   git
 Requires:   ovirt-puppet
 
-Requires:   puppet
-Requires:   puppet-server
-
 %description
 This is a Foreman-Installer plugin that allows you to install and configure
 the Fusor Foreman plugin

--- a/hooks/lib/base_seeder.rb
+++ b/hooks/lib/base_seeder.rb
@@ -1,4 +1,4 @@
-require 'foreman_api'
+require 'apipie-bindings'
 require 'uri'
 
 class BaseSeeder
@@ -16,7 +16,7 @@ class BaseSeeder
   end
 
   def foreman
-    @foreman ||= Foreman.new(:base_url => @foreman_url, :username => @username, :password => @password)
+    @foreman ||= Foreman.new(ApipieBindings::API.new(:uri => @foreman_url, :username => @username, :password => @password, :api_version => 2))
   end
 
   private
@@ -27,19 +27,19 @@ class BaseSeeder
   end
 
   def find_default_os(foreman_host)
-    @foreman.operating_system.show! 'id' => foreman_host['operatingsystem_id'],
+    @foreman.operatingsystems.show! 'id' => foreman_host['operatingsystem_id'],
                                     :error_message => "operating system for #{@fqdn} not found, DB inconsitency?"
   end
 
   def additional_oses(os)
     additional = []
     if os['name'] == 'RedHat' && os['major'] == '6'
-      additional << foreman.operating_system.show_or_ensure({'id' => 'RedHat 7.0',
+      additional << foreman.operatingsystems.show_or_ensure({'id' => 'RedHat 7.0',
                                                              'name' => 'RedHat', 'major' => '7', 'minor' => '0',
                                                              'family' => 'Redhat'}, {})
     end
     if os['name'] == 'CentOS' && os['major'] == '6'
-      additional << foreman.operating_system.show_or_ensure({'id' => 'CentOS 7.0',
+      additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 7.0',
                                                              'name' => 'CentOS', 'major' => '7', 'minor' => '0',
                                                              'family' => 'Redhat'}, {})
     end
@@ -49,7 +49,7 @@ class BaseSeeder
     # the hosts that are provisioned are CentOS 6.6.  We'll need to update this
     # once we have support for the Red Hat content in place
     # (subscriptions...etc.)
-    additional << foreman.operating_system.show_or_ensure({'id' => 'CentOS 6.6',
+    additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 6.6',
                                                            'name' => 'CentOS', 'major' => '6',
                                                            'minor' => '6', 'family' => 'Redhat'}, {})
 
@@ -57,8 +57,8 @@ class BaseSeeder
   end
 
   def find_foreman_host
-    @foreman.host.show! 'id' => @fqdn,
-                        :error_message => "host #{@fqdn} not found in foreman, puppet haven't run yet?"
+    @foreman.hosts.show! 'id' => @fqdn,
+                         :error_message => "host #{@fqdn} not found in foreman, puppet haven't run yet?"
   end
 
 end

--- a/hooks/lib/base_seeder.rb
+++ b/hooks/lib/base_seeder.rb
@@ -34,14 +34,14 @@ class BaseSeeder
   def additional_oses(os)
     additional = []
     if os['name'] == 'RedHat' && os['major'] == '6'
-      additional << foreman.operatingsystems.show_or_ensure({'id' => 'RedHat 7.0',
-                                                             'name' => 'RedHat', 'major' => '7', 'minor' => '0',
-                                                             'family' => 'Redhat'}, {})
+      additional << foreman.operatingsystems.show_or_ensure({'id' => 'RedHat 7.0'},
+                                                            {'name' => 'RedHat', 'major' => '7', 'minor' => '0',
+                                                             'family' => 'Redhat'})
     end
     if os['name'] == 'CentOS' && os['major'] == '6'
-      additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 7.0',
-                                                             'name' => 'CentOS', 'major' => '7', 'minor' => '0',
-                                                             'family' => 'Redhat'}, {})
+      additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 7.0'},
+                                                            {'name' => 'CentOS', 'major' => '7', 'minor' => '0',
+                                                             'family' => 'Redhat'})
     end
 
     # TODO: The creation of OS is currently based upon the OS of the server;
@@ -49,9 +49,9 @@ class BaseSeeder
     # the hosts that are provisioned are CentOS 6.6.  We'll need to update this
     # once we have support for the Red Hat content in place
     # (subscriptions...etc.)
-    additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 6.6',
-                                                           'name' => 'CentOS', 'major' => '6',
-                                                           'minor' => '6', 'family' => 'Redhat'}, {})
+    additional << foreman.operatingsystems.show_or_ensure({'id' => 'CentOS 6.6'},
+                                                          {'name' => 'CentOS', 'major' => '6',
+                                                           'minor' => '6', 'family' => 'Redhat'})
 
     additional
   end

--- a/hooks/lib/foreman.rb
+++ b/hooks/lib/foreman.rb
@@ -1,41 +1,21 @@
 class Foreman
-  RESOURCES = {
-      :organization => 'Organization',
-      :location => 'Location',
-      :subnet => 'Subnet',
-      :domain => 'Domain',
-      :smart_proxy => 'SmartProxy',
-      :host => 'Host',
-      :config_template => 'ConfigTemplate',
-      :operating_system => 'OperatingSystem',
-      :medium => 'Medium',
-      :template_kind => 'TemplateKind',
-      :os_default_template => 'OsDefaultTemplate',
-      :partition_table => 'Ptable',
-      :parameter => 'Parameter',
-      :hostgroup => 'Hostgroup',
-      :environment => 'Environment',
-      :setting => 'Setting',
-      :template_combination => 'TemplateCombination',
-      :puppetclass => 'Puppetclass',
-  }
 
-  def initialize(options)
-    @options = options
-    @resource = Hash.new { |h, k| h[k] = Resource.new(ForemanApi::Resources.const_get(RESOURCES[k]).new(@options), k) }
+  def initialize(api)
+    @api = api
   end
 
   def method_missing(name, *args, &block)
     name = name.to_sym
-    if RESOURCES.keys.include?(name)
-      @resource[name]
+    if @api.resources.any? { |r| r.name == name }
+      Resource.new(@api.resource(name))
     else
       super
     end
   end
 
   def respond_to?(name)
-    if RESOURCES.keys.include?(name)
+    name = name.to_sym
+    if @api.resources.any? { |r| r.name == name }
       true
     else
       super
@@ -43,47 +23,36 @@ class Foreman
   end
 
   def version
-    version, _ = ForemanApi::Base.new(@options).http_call 'get', '/api/status'
+    version = @api.resource(:home).action(:status).call
     version['version']
   end
 
   class Resource
-    def initialize(api_resource, name)
+    def initialize(api_resource)
       @api_resource = api_resource
-      @name = name
     end
 
     def method_missing(name, *args, &block)
-      if @api_resource.respond_to?(name)
-        @api_resource.send name, *args, &block
+      if @api_resource.actions.any? { |a| a.name == name }
+        @api_resource.call(name, *args, &block)
       else
         super
       end
     end
 
     def respond_to?(name)
-      @api_resource.respond_to?(name) || super
+      @api_resource.actions.any? { |a| a.name == name } || super
     end
 
     def show_or_ensure(identifier, attributes)
       begin
-        object, _ = @api_resource.show(identifier)
+        object = @api_resource.action(:show).call(identifier)
         if should_update?(object, attributes)
-          object, _ = @api_resource.update(identifier.merge({@name.to_s => attributes}))
-          object, _ = @api_resource.show(identifier)
+          object = @api_resource.action(:update).call(identifier.merge({ @api_resource.name.to_s => attributes }))
+          object = @api_resource.action(:show).call(identifier)
         end
       rescue RestClient::ResourceNotFound
-        object, _ = @api_resource.create({@name.to_s => attributes}.merge(identifier.tap {|h| h.delete('id')}))
-      end
-      object
-    end
-
-    def show!(*args)
-      error_message = args.delete(:error_message) || 'unknown error'
-      begin
-        object, _ = @api_resource.show(*args)
-      rescue RestClient::ResourceNotFound
-        raise StandardError, error_message
+        object = @api_resource.action(:create).call({ @api_resource.name.to_s => attributes }.merge(identifier.tap { |h| h.delete('id') }))
       end
       object
     end
@@ -93,17 +62,27 @@ class Foreman
         object = first!(condition)
         if should_update?(object, attributes)
           identifier = { 'id' => object['id'] }
-          object, _ = @api_resource.update(identifier.merge({@name.to_s => attributes}))
-          object, _ = @api_resource.show(identifier)
+          object, _ = @api_resource.action(:update).call(identifier.merge({ @name.to_s => attributes }))
+          object, _ = @api_resource.action(:show).call(identifier)
         end
       rescue StandardError
-        object, _ = @api_resource.create({@name.to_s => attributes})
+        object, _ = @api_resource.action(:create).call({ @name.to_s => attributes })
+      end
+      object
+    end
+
+    def show!(*args)
+      error_message = args.delete(:error_message) || 'unknown error'
+      begin
+        object = @api_resource.action(:show).call(*args)
+      rescue RestClient::ResourceNotFound
+        raise StandardError, error_message
       end
       object
     end
 
     def index(*args)
-      object, _ = @api_resource.index(*args)
+      object = @api_resource.action(:index).call(*args)
       object['results']
     end
 

--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -32,12 +32,12 @@ class ProvisioningSeeder < BaseSeeder
     default_environment = find_default_environment
     foreman_host = find_foreman_host
 
-    default_domain = @foreman.domain.show_or_ensure({'id' => @domain},
+    default_domain = @foreman.domains.show_or_ensure({'id' => @domain},
                                                     {'name' => @domain,
                                                      'fullname' => 'Default domain used for provisioning',
                                                      'dns_id' => default_proxy['id']})
 
-    default_subnet = @foreman.subnet.show_or_ensure({'id' => 'default'},
+    default_subnet = @foreman.subnets.show_or_ensure({'id' => 'default'},
                                                     {'name' => 'default',
                                                      'mask' => @netmask,
                                                      'network' => @network,
@@ -51,40 +51,40 @@ class ProvisioningSeeder < BaseSeeder
                                                      'tftp_id' => default_proxy['id'],
                                                      'boot_mode' => 'DHCP'})
 
-    kinds = @foreman.template_kind.index
+    kinds = @foreman.template_kinds.index
     provisioning = kinds.detect { |k| k['name'] == 'provision' }
     pxe_linux = kinds.detect { |k| k['name'] == 'PXELinux' }
     default_config_templates = []
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'redhat_register'},
                                             {'template' => redhat_register_snippet, 'snippet' => '1', 'name' => 'redhat_register'})
 
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'custom_deployment_repositories'},
                                             {'template' => custom_deployment_repositories_snippet, 'snippet' => '1', 'name' => 'custom_deployment_repositories'})
 
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'Kickstart RHEL default'},
                                             {'template' => kickstart_rhel_default, 'template_kind_id' => provisioning['id'], 'name' => 'Kickstart RHEL default'})
 
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'Kickstart default'},
                                             {'template' => kickstart_default, 'template_kind_id' => provisioning['id'], 'name' => 'Kickstart default'})
 
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'ssh_public_key'},
                                             {'template' => ssh_public_key_snippet, 'snippet' => '1', 'name' => 'ssh_public_key'})
 
-    default_config_templates << @foreman.config_template.show_or_ensure(
+    default_config_templates << @foreman.config_templates.show_or_ensure(
                                             {'id' => 'kickstart_networking_setup'},
                                             {'template' => kickstart_networking_setup_snippet, 'snippet' => '1', 'name' => 'kickstart_networking_setup'})
 
     name = 'PXELinux global default'
-    pxe_template = @foreman.config_template.show_or_ensure({'id' => name},
-                                                           {'template' => template})
+    pxe_template = @foreman.config_templates.show_or_ensure({'id' => name},
+                                                            {'template' => template})
     default_config_templates << pxe_template
 
-    @foreman.config_template.build_pxe_default
+    @foreman.config_templates.build_pxe_default
 
     @hostgroups = []
     @media = []
@@ -98,10 +98,10 @@ class ProvisioningSeeder < BaseSeeder
 #      next if os['name'] == 'CentOS' && os['major'] == '6' # we don's support CentOS6 for provisioning anymore
 
       group_id = "base_#{os['name']}_#{os['major']}"
-      medium = @foreman.medium.index('search' => "name ~ #{os['name']}").first
+      medium = @foreman.media.index('search' => "name ~ #{os['name']}").first
 
       if os['architectures'].nil? || os['architectures'].empty?
-        @foreman.operating_system.update 'id' => os['id'],
+        @foreman.operatingsystems.update 'id' => os['id'],
                                          'operatingsystem' => {'architecture_ids' => [foreman_host['architecture_id']]}
       end
 
@@ -109,7 +109,7 @@ class ProvisioningSeeder < BaseSeeder
         if medium.nil?
           say HighLine.color("Installation medium for #{os['name']} not found, provisioning will not work for hostgroup #{group_id} unless you create it manually", :info)
         else
-          @foreman.operating_system.update 'id' => os['id'], 'operatingsystem' => {'medium_ids' => [medium['id']]}
+          @foreman.operatingsystems.update 'id' => os['id'], 'operatingsystem' => {'medium_ids' => [medium['id']]}
         end
       end
       @media.push medium unless medium.nil?
@@ -127,7 +127,7 @@ class ProvisioningSeeder < BaseSeeder
                          'subnet_id' => default_subnet['id']}
       hostgroup_attrs['medium_id'] = medium['id'] unless medium.nil?
 
-      hostgroup_base = @foreman.hostgroup.show_or_ensure({'id' => group_id}, hostgroup_attrs)
+      hostgroup_base = @foreman.hostgroups.show_or_ensure({'id' => group_id}, hostgroup_attrs)
       @hostgroups.push hostgroup_base
 
       # TODO: hostgroup creation... when we move to the foreman deployment feature,
@@ -138,7 +138,7 @@ class ProvisioningSeeder < BaseSeeder
       hostgroup_attrs = {'name' => 'oVirt',
                          'parent_id' => hostgroup_base['id'],
                          'environment_id' => default_environment['id']}
-      hostgroup_ovirt = @foreman.hostgroup.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
+      hostgroup_ovirt = @foreman.hostgroups.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
       @hostgroups.push hostgroup_ovirt
 
       # creating ovirt-engine hostgroup
@@ -146,7 +146,7 @@ class ProvisioningSeeder < BaseSeeder
       hostgroup_attrs = {'name' => 'oVirt-Engines',
                          'parent_id' => hostgroup_ovirt['id'],
                          'puppetclass_ids' => puppetclass_ids}
-      hostgroup_ovirt_engines = @foreman.hostgroup.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_ovirt['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
+      hostgroup_ovirt_engines = @foreman.hostgroups.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_ovirt['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
       @hostgroups.push hostgroup_ovirt_engines
 
       # creating ovirt-hypervisor hostgroup
@@ -154,26 +154,26 @@ class ProvisioningSeeder < BaseSeeder
       hostgroup_attrs = {'name' => 'oVirt-Hypervisors',
                          'parent_id' => hostgroup_ovirt['id'],
                          'puppetclass_ids' => puppetclass_ids}
-      hostgroup_ovirt_hypervisors = @foreman.hostgroup.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_ovirt['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
+      hostgroup_ovirt_hypervisors = @foreman.hostgroups.search_or_ensure("title = #{hostgroup_base['name']}/#{hostgroup_ovirt['name']}/#{hostgroup_attrs['name']}", hostgroup_attrs)
       @hostgroups.push hostgroup_ovirt_hypervisors
 
       if !@default_ssh_public_key.nil? && !@default_ssh_public_key.empty?
-        @foreman.parameter.show_or_ensure({'id' => 'ssh_public_key', 'operatingsystem_id' => os['id']},
-                                          {
-                                              'name' => 'ssh_public_key',
-                                              'value' => @default_ssh_public_key,
-                                          })
+        @foreman.parameters.show_or_ensure({'id' => 'ssh_public_key', 'operatingsystem_id' => os['id']},
+                                           {
+                                             'name' => 'ssh_public_key',
+                                             'value' => @default_ssh_public_key,
+                                           })
       end
-      @foreman.parameter.show_or_ensure({'id' => 'ntp-server', 'operatingsystem_id' => os['id']},
-                                        {
-                                            'name' => 'ntp-server',
-                                            'value' => @ntp_host,
-                                        })
-      @foreman.parameter.show_or_ensure({'id' => 'time-zone', 'operatingsystem_id' => os['id']},
-                                        {
-                                            'name' => 'time-zone',
-                                            'value' => @timezone,
-                                        })
+      @foreman.parameters.show_or_ensure({'id' => 'ntp-server', 'operatingsystem_id' => os['id']},
+                                         {
+                                           'name' => 'ntp-server',
+                                           'value' => @ntp_host,
+                                         })
+      @foreman.parameters.show_or_ensure({'id' => 'time-zone', 'operatingsystem_id' => os['id']},
+                                         {
+                                           'name' => 'time-zone',
+                                           'value' => @timezone,
+                                         })
     end
 
     default_hostgroup = @hostgroups.last
@@ -197,7 +197,7 @@ class ProvisioningSeeder < BaseSeeder
 
   def ovirt_engine_puppetclass_ids(search_string)
     class_ids = []
-    classes = @foreman.puppetclass.index('search' => search_string, 'style' => 'list')
+    classes = @foreman.puppetclasses.index('search' => search_string, 'style' => 'list')
 
     class_ids.push(classes.find{ |c| c['name'] == 'ovirt' }['id'])
     class_ids.push(classes.find{ |c| c['name'] == 'ovirt::repo' }['id'])
@@ -209,7 +209,7 @@ class ProvisioningSeeder < BaseSeeder
 
   def ovirt_hypervisor_puppetclass_ids(search_string)
     class_ids = []
-    classes = @foreman.puppetclass.index('search' => search_string, 'style' => 'list')
+    classes = @foreman.puppetclasses.index('search' => search_string, 'style' => 'list')
 
     class_ids.push(classes.find{ |c| c['name'] == 'ovirt' }['id'])
     class_ids.push(classes.find{ |c| c['name'] == 'ovirt::hypervisor::packages' }['id'])
@@ -217,8 +217,8 @@ class ProvisioningSeeder < BaseSeeder
   end
 
   def assign_organization(objects)
-    organization = @foreman.organization.first!(%Q(name = "#{@organization}"))
-    organization = @foreman.organization.show!('id' => organization['id'])
+    organization = @foreman.organizations.first!(%Q(name = "#{@organization}"))
+    organization = @foreman.organizations.show!('id' => organization['id'])
 
     domain_ids = organization['domains'].map { |d| d['id'] }
     subnet_ids = organization['subnets'].map { |s| s['id'] }
@@ -227,18 +227,18 @@ class ProvisioningSeeder < BaseSeeder
     environment_ids = organization['environments'].map { |e| e['id'] }
     medium_ids = organization['media'].map { |m| m['id'] }
 
-    @foreman.organization.update('id' => organization['id'],
-                                 'organization' => { 'domain_ids' => (domain_ids + [objects['domain']['id']]).uniq,
-                                                     'subnet_ids' => (subnet_ids + [objects['subnet']['id']]).uniq,
-                                                     'config_template_ids' => (config_template_ids + objects['config_templates'].map{ |t| t['id'] }).uniq,
-                                                     'hostgroup_ids' => (hostgroup_ids + objects['hostgroups'].map{ |h| h['id'] }).uniq,
-                                                     'environment_ids' => (environment_ids + [objects['environments'].map{ |e| e['id'] }]).flatten.uniq,
-                                                     'medium_ids' => (medium_ids + [objects['media'].map{ |m| m['id'] }]).uniq })
+    @foreman.organizations.update('id' => organization['id'],
+                                  'organization' => { 'domain_ids' => (domain_ids + [objects['domain']['id']]).uniq,
+                                                      'subnet_ids' => (subnet_ids + [objects['subnet']['id']]).uniq,
+                                                      'config_template_ids' => (config_template_ids + objects['config_templates'].map{ |t| t['id'] }).uniq,
+                                                      'hostgroup_ids' => (hostgroup_ids + objects['hostgroups'].map{ |h| h['id'] }).uniq,
+                                                      'environment_ids' => (environment_ids + [objects['environments'].map{ |e| e['id'] }]).flatten.uniq,
+                                                      'medium_ids' => (medium_ids + [objects['media'].map{ |m| m['id'] }]).uniq })
   end
 
   def assign_location(objects)
-    location = @foreman.location.first!(%Q(name = "#{@location}"))
-    location = @foreman.location.show!('id' => location['id'])
+    location = @foreman.locations.first!(%Q(name = "#{@location}"))
+    location = @foreman.locations.show!('id' => location['id'])
 
     domain_ids = location['domains'].map { |d| d['id'] }
     subnet_ids = location['subnets'].map { |s| s['id'] }
@@ -247,45 +247,45 @@ class ProvisioningSeeder < BaseSeeder
     environment_ids = location['environments'].map { |e| e['id'] }
     medium_ids = location['media'].map { |m| m['id'] }
 
-    @foreman.location.update('id' => location['id'],
-                             'location' => { 'domain_ids' => (domain_ids + [objects['domain']['id']]).uniq,
-                                             'subnet_ids' => (subnet_ids + [objects['subnet']['id']]).uniq,
-                                             'config_template_ids' => (config_template_ids + objects['config_templates'].map{ |t| t['id'] }).uniq,
-                                             'hostgroup_ids' => (hostgroup_ids + objects['hostgroups'].map{ |h| h['id'] }).uniq,
-                                             'environment_ids' => (environment_ids + [objects['environments'].map{ |e| e['id'] }]).flatten.uniq,
-                                             'medium_ids' => (medium_ids + [objects['media'].map{ |m| m['id'] }]).uniq })
+    @foreman.locations.update('id' => location['id'],
+                              'location' => { 'domain_ids' => (domain_ids + [objects['domain']['id']]).uniq,
+                                              'subnet_ids' => (subnet_ids + [objects['subnet']['id']]).uniq,
+                                              'config_template_ids' => (config_template_ids + objects['config_templates'].map{ |t| t['id'] }).uniq,
+                                              'hostgroup_ids' => (hostgroup_ids + objects['hostgroups'].map{ |h| h['id'] }).uniq,
+                                              'environment_ids' => (environment_ids + [objects['environments'].map{ |e| e['id'] }]).flatten.uniq,
+                                              'medium_ids' => (medium_ids + [objects['media'].map{ |m| m['id'] }]).uniq })
   end
 
   def create_discovery_env(template)
-    env = @foreman.environment.show_or_ensure({'id' => @discovery_env_name},
-                                              {'name' => @discovery_env_name})
+    env = @foreman.environments.show_or_ensure({'id' => @discovery_env_name},
+                                               {'name' => @discovery_env_name})
     # if the template has combination already, we don't update it
     unless template.nil? || template['template_combinations'].any? { |c| c['environment_id'] == env['id'].to_i and c['hostgroup_id'].nil? }
-      @foreman.config_template.update 'id' => template['name'],
-                                      'config_template' => {'template_combinations_attributes' => [{'environment_id' => env['id']}]}
+      @foreman.config_templates.update 'id' => template['name'],
+                                       'config_template' => {'template_combinations_attributes' => [{'environment_id' => env['id']}]}
     end
     env
   end
 
   def setup_setting(default_hostgroup)
-    @foreman.setting.show_or_ensure({'id' => 'base_hostgroup'},
-                                    {'value' => default_hostgroup['name'].to_s})
+    @foreman.settings.show_or_ensure({'id' => 'base_hostgroup'},
+                                     {'value' => default_hostgroup['name'].to_s})
   rescue NoMethodError => e
     @logger.error "Setting with name 'base_hostgroup' not found, you must run 'foreman-rake db:seed' " +
                       "and rerun installer to fix this issue."
   end
 
   def setup_idle_timeout
-    @foreman.setting.show_or_ensure({'id' => 'idle_timeout'},
-                                    {'value' => @foreman.version.start_with?('1.6') ? 180 : '180'})
+    @foreman.settings.show_or_ensure({'id' => 'idle_timeout'},
+                                     {'value' => 180})
   rescue NoMethodError => e
     @logger.error "Setting with name 'idle_timeout' not found, you must run 'foreman-rake db:seed' " +
                       "and rerun installer to fix this issue."
   end
 
   def setup_ignore_puppet_facts_for_provisioning
-    @foreman.setting.show_or_ensure({'id' => 'ignore_puppet_facts_for_provisioning'},
-                                    {'value' => @foreman.version.start_with?('1.6') ? true : 'true'})
+    @foreman.settings.show_or_ensure({'id' => 'ignore_puppet_facts_for_provisioning'},
+                                     {'value' => true})
   rescue NoMethodError => e
     @logger.error "Setting with name 'ignore_puppet_facts_for_provisioning' not found, you must run 'foreman-rake db:seed' " +
                       "and rerun installer to fix this issue."
@@ -293,8 +293,8 @@ class ProvisioningSeeder < BaseSeeder
   end
 
   def setup_default_root_pass
-    @foreman.setting.show_or_ensure({'id' => 'root_pass'},
-                                    {'value' => @default_root_pass.to_s.crypt('$5$fm')})
+    @foreman.settings.show_or_ensure({'id' => 'root_pass'},
+                                     {'value' => @default_root_pass.to_s.crypt('$5$fm')})
   rescue NoMethodError => e
     @logger.error "Setting with name 'root_pass' not found, you must run 'foreman-rake db:seed' " +
                       "and rerun installer to fix this issue."
@@ -307,11 +307,11 @@ class ProvisioningSeeder < BaseSeeder
     end
     default_ptable = nil
     additional_ptables_names.push(default_ptable_name).each do |ptable_name|
-      ptable = @foreman.partition_table.first! %Q(name ~ "#{ptable_name}*")
+      ptable = @foreman.ptables.first! %Q(name ~ "#{ptable_name}*")
       default_ptable = ptable if default_ptable_name == ptable['name']
       if os['ptables'].nil? || os['ptables'].empty?
-        ids = @foreman.partition_table.show!('id' => ptable['id'])['operatingsystems'].map { |o| o['id'] }
-        @foreman.partition_table.update 'id' => ptable['id'], 'ptable' => {'operatingsystem_ids' => (ids + [os['id']]).uniq}
+        ids = @foreman.ptables.show!('id' => ptable['id'])['operatingsystems'].map { |o| o['id'] }
+        @foreman.ptables.update 'id' => ptable['id'], 'ptable' => {'operatingsystem_ids' => (ids + [os['id']]).uniq}
       end
     end
     default_ptable
@@ -330,44 +330,44 @@ class ProvisioningSeeder < BaseSeeder
 
     {'provision' => provision_tmpl_name, 'PXELinux' => tmpl_name, 'iPXE' => ipxe_tmpl_name}.each do |kind_name, tmpl_name|
       next if tmpl_name.nil?
-      kinds = @foreman.template_kind.index
+      kinds = @foreman.template_kinds.index
       kind = kinds.detect { |k| k['name'] == kind_name }
 
       # we prefer foreman_bootdisk templates
-      tmpls = @foreman.config_template.search "name ~ \"#{tmpl_name}*\" and kind = #{kind_name}"
+      tmpls = @foreman.config_templates.search "name ~ \"#{tmpl_name}*\" and kind = #{kind_name}"
       tmpl = tmpls.detect { |t| t['name'] =~ /.*sboot disk.*s/ } || tmpls.first
       raise StandardError, "no template found by search 'name ~ \"#{tmpl_name}*\"'" if tmpl.nil?
 
       # if there's no provisioning template for this os family found it means, it's not associated so we add relation
       # otherwise we still must check that it's assigned for right os not just family
-      assigned_tmpl = @foreman.config_template.first %Q(name ~ "#{tmpl_name}*" and kind = #{kind_name} and operatingsystem = "#{os['name']}")
+      assigned_tmpl = @foreman.config_templates.first %Q(name ~ "#{tmpl_name}*" and kind = #{kind_name} and operatingsystem = "#{os['name']}")
       if assigned_tmpl.nil?
         @foreman.config_template.update 'id' => tmpl['id'], 'config_template' => {'operatingsystem_ids' => [os['id']]}
       else
-        assigned_os_ids = @foreman.config_template.show!('id' => tmpl['id'])['operatingsystems'].map { |o| o['id'] }
+        assigned_os_ids = @foreman.config_templates.show!('id' => tmpl['id'])['operatingsystems'].map { |o| o['id'] }
         if !assigned_os_ids.include?(os['id'])
           @foreman.config_template.update 'id' => tmpl['id'], 'config_template' => {'operatingsystem_ids' => assigned_os_ids + [os['id']]}
         end
       end
 
       # finally we setup default template from possible values we assigned in previous steps
-      os_tmpls = @foreman.os_default_template.index 'operatingsystem_id' => os['id']
+      os_tmpls = @foreman.os_default_templates.index 'operatingsystem_id' => os['id']
       os_tmpl = os_tmpls.detect { |t| t['template_kind_name'] == kind_name }
       if os_tmpl.nil?
-        @foreman.os_default_template.create 'os_default_template' => {'config_template_id' => tmpl['id'], 'template_kind_id' => kind['id']},
-                                            'operatingsystem_id' => os['id']
+        @foreman.os_default_templates.create 'os_default_template' => {'config_template_id' => tmpl['id'], 'template_kind_id' => kind['id']},
+                                             'operatingsystem_id' => os['id']
       end
     end
   end
 
   def find_default_environment
-    @foreman.environment.show! 'id' => @environment,
-                               :error_message => "environment #{@environment} not found in foreman, puppet haven't run yet?"
+    @foreman.environments.show! 'id' => @environment,
+                                :error_message => "environment #{@environment} not found in foreman, puppet haven't run yet?"
   end
 
   def find_default_proxy
-    @foreman.smart_proxy.show! 'id' => @fqdn,
-                               :error_message => "smart proxy #{@fqdn} haven't been registered in foreman yet, installer failure?"
+    @foreman.smart_proxies.show! 'id' => @fqdn,
+                                 :error_message => "smart proxy #{@fqdn} haven't been registered in foreman yet, installer failure?"
   end
 
   def kickstart_rhel_default


### PR DESCRIPTION
This PR contains 2 changes:
1. Based on the recommendation from foreman core developers, we are moving the seeding from using the foreman api to using the apipie bindings
2.  Moving from using a foreman puppet environment to using katello's content management.  This means managing the content via products, repositories and content views.

Refer to the commits for more details.
