### PR TITLE
Updates from testing with Sat 6.1 3.11.1 compose

### DIFF
--- a/config/fusor-installer.answers.yaml
+++ b/config/fusor-installer.answers.yaml
@@ -37,10 +37,6 @@ capsule:
   puppetca: true
 
 foreman::plugin::bootdisk: true
-foreman::plugin::discovery:
-  # Overriding kernel/initrd to match what is in foreman-discovery-image (needed as of 2/27/15)
-  kernel: fdi-image-rhel_7-vmlinuz
-  initrd: fdi-image-rhel_7-img
 foreman::plugin::hooks: true
 foreman::plugin::tasks: true
 foreman::plugin::chef: false

--- a/config/fusor-installer.yaml
+++ b/config/fusor-installer.yaml
@@ -38,6 +38,9 @@
 
 # The mapping hash provides Kafo with the information to find plugin classes
 :mapping:
+  :katello::plugin::gutterball:
+    :dir_name: katello
+    :manifest_name: plugin/gutterball
   :foreman::plugin::bootdisk:
     :dir_name: foreman
     :manifest_name: plugin/bootdisk

--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -17,12 +17,14 @@ class ProvisioningSeeder < BaseSeeder
     @from = kafo.param('foreman_plugin_fusor', 'from').value
     @to = kafo.param('foreman_plugin_fusor', 'to').value
     @gateway = kafo.param('capsule', 'dhcp_gateway').value
-    @kernel = kafo.param('foreman_plugin_discovery', 'kernel').value
-    @initrd = kafo.param('foreman_plugin_discovery', 'initrd').value
+    
     @default_root_pass = kafo.param('foreman_plugin_fusor', 'root_password').instance_variable_get('@value')
     @default_ssh_public_key = kafo.param('foreman_plugin_fusor', 'ssh_public_key').value
     @ntp_host = kafo.param('foreman_plugin_fusor', 'ntp_host').value
     @timezone = kafo.param('foreman_plugin_fusor', 'timezone').value
+
+    @kernel = "fdi-image-rhel_7-vmlinuz"
+    @initrd = "fdi-image-rhel_7-img"
   end
 
   def seed

--- a/hooks/pre_values/10-register_fusor_modules.rb
+++ b/hooks/pre_values/10-register_fusor_modules.rb
@@ -3,7 +3,6 @@ if app_value(:provisioning_wizard) != 'none'
   add_module('foreman::plugin::fusor',
              {:manifest_name => 'plugin/fusor',  :dir_name => 'foreman'})
 
-  # make sure discovery and foreman-tasks are enabled
-  kafo.module('foreman_plugin_discovery').enable
+  # make sure foreman-tasks is enabled
   kafo.module('foreman_plugin_tasks').enable
 end


### PR DESCRIPTION
Below changes were required to reach a success run of fusor-installer against Sat 6.1 compose 3.11.1.  (Also tested with compose 3.17).
- Add stanza for gutterball config
- Hard code parameters for kernel/initrd of foreman plugin discovery since puppet params have been deleted
- Remove explicit enable of foreman_plugin_discovery
