### PR TITLE
answers: add gutterball plugin

### DIFF
--- a/config/fusor-installer.answers.yaml
+++ b/config/fusor-installer.answers.yaml
@@ -45,6 +45,8 @@ foreman::plugin::puppetdb: false
 foreman::plugin::setup: false
 foreman::plugin::templates: false
 
+katello::plugin::gutterball: true
+
 # Issue #4244 - Commenting these out due to the seg fault
 # caused on Ruby 1.8.7, the Katello RPM ensures these
 # are installed instead


### PR DESCRIPTION
This plugin is required to install newer versions of katello. If not
included, errors like the following may be observed by the fusor-installer:

/usr/bin/wget --timeout=30 --tries=5 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init >/var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done returned 4 instead of one of [0]
/Stage[main]/Candlepin::Service/Exec[cpinit]/returns: change from notrun to 0 failed: /usr/bin/wget --timeout=30 --tries=5 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init >/var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done returned 4 instead of one of [0]
