### PR TITLE
Fixes BZ#1218296 - Add option to set hostname

### DIFF
--- a/hooks/boot/20-add_hostname_option.rb
+++ b/hooks/boot/20-add_hostname_option.rb
@@ -1,0 +1,1 @@
+app_option '--hostname', 'HOSTNAME', 'Hostname of the system (when it is not managed by DHCP)'

--- a/hooks/pre_validations/05-set_hostname.rb
+++ b/hooks/pre_validations/05-set_hostname.rb
@@ -25,4 +25,19 @@ unless app_value(:hostname).nil?
       kafo.class.exit(101)
     end
   end
+
+  # set /etc/hosts if needed
+  `hostname -f`
+  if $?.exitstatus > 0 
+    filename = '/etc/hosts'
+    logger.debug("hostname -f failed. Setting temporary hostname for loopback in #{filename}")
+    unless kafo.noop?
+      open(filename, 'a') do |f|
+        f << "# temporary hostname for loopback\n"
+        f << "127.0.0.1 #{hostname}\n"
+      end
+    end
+  end
+
+  nil
 end

--- a/hooks/pre_validations/05-set_hostname.rb
+++ b/hooks/pre_validations/05-set_hostname.rb
@@ -1,0 +1,28 @@
+unless app_value(:hostname).nil?
+  hostname = app_value(:hostname)
+
+  command = "hostname \"#{hostname}\" 2>&1"
+  logger.debug(command)
+  unless kafo.noop?
+    result = `command`
+    if $?.exitstatus > 0
+      say "<%= color('Hostname setup failed: #{result}', :bad) %>"
+      kafo.class.exit(101)
+    end
+  end
+
+  filename = '/etc/sysconfig/network'
+  logger.debug("Writing hostname (#{hostname}) to #{filename}")
+  unless kafo.noop?
+    entry = "HOSTNAME=#{hostname}"
+    begin
+      text = File.read(filename) 
+      text.gsub!(/^HOSTNAME=.*?$/, entry)
+      text += "#{entry}\n" unless text =~ /^HOSTNAME=/
+      File.open(filename, "w") { |file| file.write(text) }
+    rescue => error
+      say "<%= color('Hostname setup failed: #{error}', :bad) %>"
+      kafo.class.exit(101)
+    end
+  end
+end

--- a/hooks/pre_validations/15-set_hostname_cleanup.rb
+++ b/hooks/pre_validations/15-set_hostname_cleanup.rb
@@ -1,0 +1,13 @@
+unless app_value(:hostname).nil?
+  hostname = app_value(:hostname)
+
+  filename = '/etc/hosts'
+  logger.debug("Cleaning temporary hostanme for loopback if set")
+  unless kafo.noop?
+    text = File.read(filename) 
+    text.gsub!(/# temporary hostname for loopback\n127.0.0.1 #{hostname}\n/m, '')
+    File.open(filename, "w") { |file| file.write(text) }
+  end
+
+  nil
+end


### PR DESCRIPTION
This PR adds option --hostname to the installer. If the installer is invoked with the parameter it sets the hostname using system `hostname <hostanme>` command and updates `/etc/sysconfig/network`.

The actions are logged.

--noop mode is supported
