### PR TITLE
Fixes BZ#1218296 - replace hostname check with a hook

### DIFF
--- a/fusor-installer.spec
+++ b/fusor-installer.spec
@@ -53,6 +53,7 @@ cp config/fusor-installer.answers.yaml %{buildroot}%{_sysconfdir}/katello-instal
 %files
 %defattr(-,root,root,-)
 %doc LICENSE
+%{_datadir}/katello-installer/hooks/boot/05-remove_hostname_check.rb
 %{_datadir}/katello-installer/hooks/boot/10-add_options.rb
 %{_datadir}/katello-installer/hooks/lib/base_seeder.rb
 %{_datadir}/katello-installer/hooks/lib/foreman.rb
@@ -63,6 +64,7 @@ cp config/fusor-installer.answers.yaml %{buildroot}%{_sysconfdir}/katello-instal
 %{_datadir}/katello-installer/hooks/post/10-setup_provisioning.rb
 %{_datadir}/katello-installer/hooks/pre_validations/10-gather_and_set_fusor_values.rb
 %{_datadir}/katello-installer/hooks/pre_values/10-register_fusor_modules.rb
+%{_datadir}/katello-installer/hooks/pre/10-check_hostname.rb
 %{_datadir}/katello-installer/modules/network
 %{_datadir}/katello-installer/modules/foreman/manifests/plugin/fusor.pp
 %{_datadir}/katello-installer/modules/foreman/manifests/plugin/fusor_network.pp

--- a/hooks/boot/05-remove_hostname_check.rb
+++ b/hooks/boot/05-remove_hostname_check.rb
@@ -1,0 +1,8 @@
+# remove hostname check if it exists
+check_file = File.join(KafoConfigure.root_dir, 'checks', 'hostname.rb')
+hook_file = File.join(KafoConfigure.root_dir, 'hooks', 'pre', '10-check_hostname.rb')
+begin
+  File.delete(check_file)
+  logger.info "The check #{check_file} was removed. It is replaced with the hook #{hook_file}"
+rescue Exception
+end

--- a/hooks/pre/10-check_hostname.rb
+++ b/hooks/pre/10-check_hostname.rb
@@ -1,0 +1,40 @@
+require 'facter'
+
+BASE = %q(If needed, change the hostname permanently via 'hostname' command and editing 
+appropriate configuration file.
+(e.g. on Red Hat systems /etc/sysconfig/network).
+If 'hostname -f' still returns unexpected result, check /etc/hosts and put
+hostname entry in the correct order, for example:
+ 
+  1.2.3.4 full.hostname.com full
+ 
+Fully qualified hostname must be the first entry on the line)
+
+DIFFERENT = %q(Output of 'facter fqdn' is different from 'hostname -f'
+ 
+Make sure above command gives the same output. )
+
+INVALID = %q(Output of 'hostname -f' does not seems to be valid FQDN
+Make sure above command gives fully qualified domain name. At least one
+dot must be present and underscores are not allowed. )
+
+UPCASE = %q(The hostname contains a a capital letter.
+This is not supported. Please modify the hostname to be all lowercase. )
+ 
+
+def error_exit(message, code)
+  $stderr.puts message
+  exit code
+end
+
+fqdn = Facter.value(:fqdn)
+
+# Check that facter actually has a value that matches the hostname.
+# This should always be true for facter >= 1.7
+error_exit(DIFFERENT + BASE, 1) if fqdn != `hostname -f`.chomp
+# Every FQDN should have at least one dot
+error_exit(INVALID + BASE, 2) unless fqdn.include?('.')
+# Per https://bugzilla.redhat.com/show_bug.cgi?id=1205960 check for underscores
+error_exit(INVALID + BASE, 2) if fqdn.include?('_')
+# Capital Letters are not suported.
+error_exit(UPCASE + BASE, 3) unless fqdn.downcase == fqdn


### PR DESCRIPTION
This is second attempt to fix this issue.
The first one is here https://github.com/fusor/fusor-installer/pull/11.

The strategy is to let the hostname check be executed after the networking is set. To make that happen we have to implement it as a hook that is executed later (we used `pre` group for this).

The dirty part is we have to delete the original check owned by katello-installer.
