### PR TITLE
silence 400 errors during install time puppet run

### DIFF
--- a/hooks/lib/host_seeder.rb
+++ b/hooks/lib/host_seeder.rb
@@ -1,0 +1,32 @@
+require 'facter'
+
+class HostSeeder < BaseSeeder
+  attr_accessor :fqdn
+
+  def initialize(kafo)
+    super
+  end
+
+  def seed
+    say HighLine.color("Starting host creation", :good)
+
+    prod_env_attrs = {'name' => "production"}
+    prod_env = @foreman.environments.show_or_ensure({'id' => "production"}, prod_env_attrs)
+
+    fusor_server_attrs = {'name'            => @fqdn,
+                          'mac'             => Facter.value('macaddress'),
+                          'ip'              => Facter.value('ipaddress'),
+                          'location_id'     => nil,
+                          'organization_id' => nil,
+                          'environment_id'  => find_production_environment['id'],
+                          'managed'         => "0"}
+    fusor_server = @foreman.hosts.show_or_ensure({'id' => @fqdn}, fusor_server_attrs)
+  end
+
+  def find_production_environment
+    @foreman.environments.show! 'id' => "production",
+                                 :error_message => "environment production not found"
+  end
+
+end
+


### PR DESCRIPTION
It is necessary to create the host and RHCI servers fact yaml file to silence the 400 error on the initial puppet run.

The production environment (which would otherwise be created on the first puppet run) is created and then the host is created. We do not add it to the default org or loc because later manipulation while seeding provisioning data relies on the org and loc being empty.

The other portion that is required is creating the fact yaml file which is done by creating the containing directory and running 'puppet facts find #{fqdn} --render-as yaml' and saving it with the expect #{fqdn}.yaml name.

With PR 15 (which should be merged before this), this, and a newer Sat compose I have been able to run seeral installs without errors or warnings presenting during the install.
