### PR TITLE
[WIP] Add ntp-server as a hostgroup variable

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -168,7 +168,14 @@ class ProvisioningSeeder < BaseSeeder
     hostgroup_attrs = {'name' => "Fusor Base",
                        'domain_id' => default_domain['id'],
                        'subnet_id' => default_subnet['id']}
+
     default_hostgroup = @foreman.hostgroups.show_or_ensure({'id' => "Fusor Base"}, hostgroup_attrs)
+
+    @foreman.parameters.show_or_ensure({'id' => 'ntp-server', 'hostgroup_id' => 'Fusor Base'},
+                                         {
+                                           'name' => 'ntp-server',
+                                           'value' => @ntp_host,
+                                         })
 
     setup_idle_timeout
     setup_default_root_pass


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1238260

Makes all machines in the `Fusor Base` hostgroup sync to the same `ntp` server.
# Changes
- Creates an `ntp-server` parameter on the `Fusor Base` hostgroup, which uses the value entered in the fusor installer. 
# Side-effects
- None
# Notes
- I was mistaken, Satellite is not yet set up as an NTP server. This solutions is quick, but we may want to have them sync up to satellite in the long term?

Waiting on a successful deployment to double check, after that the WIP tag will be dropped.
