### PR TITLE
1315470: do not remap cancel exit code.

### DIFF
--- a/bin/fusor-installer
+++ b/bin/fusor-installer
@@ -85,7 +85,7 @@ if [0,2].include? @result.exit_code
   exit_code = 0
 elsif @result.exit_code == 100
   # user cancelled installation
-  exit_code = 0
+  exit_code = @result.exit_code
 else
   say "  <%= color('Something went wrong!', :bad) %> Check the log for ERROR-level output"
   exit_code = @result.exit_code


### PR DESCRIPTION
We need to know if the user canceled the installation on the ISO, so we know
whether we need to restart other services. The old implementation made it
impossible to distinguish whether the installation finished normally or if it
was canceled by the user.
