### PR TITLE
1277277 - Capitalization fix

### DIFF
--- a/hooks/lib/provisioning_wizard.rb
+++ b/hooks/lib/provisioning_wizard.rb
@@ -8,7 +8,7 @@ class ProvisioningWizard < BaseWizard
         :ip => 'IP address',
         :fqdn => 'Hostname',
         :netmask => 'Network mask',
-        :network => 'DHCP Network address',
+        :network => 'DHCP network address',
         :own_gateway => 'Host gateway',
         :from => 'DHCP range start',
         :to => 'DHCP range end',


### PR DESCRIPTION
Changed "DHCP Network address" >> "DHCP network address" in fusor-installer to align with capitalization rules. 

Associated with BZ 1277277.
