### PR TITLE
Added port 5000 for crane server to be accessed

### DIFF
--- a/modules/fusor_network/manifests/init.pp
+++ b/modules/fusor_network/manifests/init.pp
@@ -215,6 +215,13 @@ class fusor_network(
       action => 'accept',
       state  => 'NEW',
     } ->
+    # This is for accessing the Crane server on port 5000 with an OSE deployment
+    firewall { '5000 accept - crane server':
+      port   => '5000',
+      proto  => 'tcp',
+      action => 'accept',
+      state  => 'NEW',
+    } ->
     #Reject everything else
     firewall { '998 reject all':
       proto   => 'all',


### PR DESCRIPTION
An OSE deployment hosts docker containers on Satellite's Crane server which is on port 5000. The OSE VMs need access to this.
