### PR TITLE
1360335 - register host after network is up

### DIFF
--- a/hooks/lib/base_wizard.rb
+++ b/hooks/lib/base_wizard.rb
@@ -114,7 +114,7 @@ class BaseWizard
         else
           label = self.class.custom_labels[attr.to_sym] || name_label.rjust(adjustment) + value_label
         end
-        label = "Do not " + label.downcase if send(attr).is_a?(TrueClass)
+        label = "Do not " + label.downcase if send(attr).is_a?(TrueClass) && attr != "register_host"
         label = label
         menu.choice(label) { attr.to_sym }
       end

--- a/hooks/lib/provisioning_wizard.rb
+++ b/hooks/lib/provisioning_wizard.rb
@@ -254,20 +254,16 @@ class ProvisioningWizard < BaseWizard
   def register_host=(answer)
     @register_host = answer
     if ['true', 'True', 'TRUE', true].include?(@register_host)
+      @register_host = true
       say "<%= color('Register this host with subscription manager to the customer portal for updates', :info) %>"
-      username = ask('Enter the USERNAME: ')
+      @portal_username = ask('Enter the USERNAME: ')
       begin
         password = ask('Enter the PASSWORD: ') { |q| q.echo = false }
         passwrd2 = ask(' Re-enter PASSWORD: ') { |q| q.echo = false }
       end while !password.eql?(passwrd2)
-      cmd = "subscription-manager register --username #{username} --password #{password} --auto-attach"
-      ret = system(cmd)
-      if ret.eql?(false)
-        say "<%= color('There was an error in registering this host!', :bad) %>"
-      else
-        say "<%= color('This host was successfully registered!', :good) %>"
-      end
-      @register_host = false
+      @portal_password = password
+    else
+      @register_host = false # ensure it's a boolean
     end
   end
 
@@ -396,6 +392,14 @@ class ProvisioningWizard < BaseWizard
     unless ['true', 'false', true, false].include?(@register_host)
       'Invalid. Please enter true or false. (Register Host?)'
     end
+  end
+
+  def portal_username
+    return @portal_username
+  end
+
+  def portal_password
+    return @portal_password
   end
 
   private

--- a/hooks/pre_validations/10-gather_and_set_fusor_values.rb
+++ b/hooks/pre_validations/10-gather_and_set_fusor_values.rb
@@ -45,6 +45,21 @@ if app_value(:provisioning_wizard) != 'none'
     end
   end
 
+  if provisioning_wizard.register_host
+    # register host
+    # network is up now let's register
+    say 'Register this host with subscription manager to the customer portal for updates'
+    cmd = "subscription-manager register --username #{provisioning_wizard.portal_username} --password #{provisioning_wizard.portal_password} --auto-attach"
+    system(cmd)
+    if $?.exitstatus > 0
+      say "<%= color('There was an error in registering this host!', :bad) %>"
+      kafo.class.exit($?.exitstatus)
+    else
+      say "<%= color('This host was successfully registered!', :good) %>"
+    end
+  end
+
+
   #If a new admin password was specified set it, otherwise use the old value (if one exists).
   if app_value(:foreman_admin_password)
     param('fusor', 'foreman_admin_password').value = app_value(:foreman_admin_password)


### PR DESCRIPTION
Move registration to after proceed with installation and only
after network is up.  If registration fails, exit. Fix prompt
so it doesn't show "Do not" for register_host.
