### PR TITLE
1365923 - config network & firewall more explicit

### DIFF
--- a/hooks/lib/base_wizard.rb
+++ b/hooks/lib/base_wizard.rb
@@ -114,8 +114,6 @@ class BaseWizard
         else
           label = self.class.custom_labels[attr.to_sym] || name_label.rjust(adjustment) + value_label
         end
-        label = "Do not " + label.downcase if send(attr).is_a?(TrueClass) && attr != "register_host"
-        label = label
         menu.choice(label) { attr.to_sym }
       end
       menu.choice(HighLine.color('Cancel installation', :cancel)) { @kafo.class.exit(100) } if self.allow_cancellation

--- a/hooks/lib/provisioning_wizard.rb
+++ b/hooks/lib/provisioning_wizard.rb
@@ -17,8 +17,8 @@ class ProvisioningWizard < BaseWizard
         :domain => 'Domain',
         :ntp_host => 'NTP sync host',
         :timezone => 'Time zone',
-        :configure_networking => 'Configure networking on this machine',
-        :configure_firewall => 'Configure firewall on this machine',
+        :configure_networking => 'Configure networking',
+        :configure_firewall => 'Configure firewall',
         :register_host => 'Register Host For Updates'
     }
   end
@@ -28,10 +28,7 @@ class ProvisioningWizard < BaseWizard
   end
 
   def self.custom_labels
-    {
-        :configure_networking => 'Configure networking',
-        :configure_firewall => 'Configure firewall'
-    }
+    {}
   end
 
   attr_accessor *attrs.keys
@@ -251,9 +248,9 @@ class ProvisioningWizard < BaseWizard
     @timezone ||= current_system_timezone
   end
 
-  def register_host=(answer)
-    @register_host = answer
-    if ['true', 'True', 'TRUE', true].include?(@register_host)
+  def get_register_host
+    @register_host = !@register_host
+    if @register_host
       @register_host = true
       say "<%= color('Register this host with subscription manager to the customer portal for updates', :info) %>"
       @portal_username = ask('Enter the USERNAME: ')
@@ -386,12 +383,6 @@ class ProvisioningWizard < BaseWizard
 
   def validate_timezone
     'Time zone is not a valid IANA time zone identifier' unless valid_timezone?(@timezone)
-  end
-
-  def validate_register_host
-    unless ['true', 'false', true, false].include?(@register_host)
-      'Invalid. Please enter true or false. (Register Host?)'
-    end
   end
 
   def portal_username


### PR DESCRIPTION
When entering the number for Configure network and firewall, the state will simply flip between true and false. If it states true, the configuration WILL happen. False indicates it will not happen.

I also changed Register host, such that the user no longer has to enter the word "true". Choosing the number will flip the state. If it transitions to true, the user is prompted for credentials for registration. If it transitions to false, it simply shows false in the menu.
