### PR TITLE
1387765 - change log level filter from info=>debug

### DIFF
--- a/config/fusor-installer.yaml
+++ b/config/fusor-installer.yaml
@@ -4,7 +4,7 @@
   :enabled: true
   :log_dir: /var/log/fusor-installer
   :log_name: fusor-installer.log
-  :log_level: info
+  :log_level: debug
   :no_prefix: false
   :mapping: {}
   :answer_file: /etc/fusor-installer/fusor-installer.answers.yaml
@@ -18,7 +18,7 @@
   :hook_dirs: []
   :custom: {}
   :low_priority_modules: []
-  :verbose_log_level: info
+  :verbose_log_level: debug
   :parser_cache_path: "./config/parser_cache.json"
   :password: H69G9HAWaY0xeIefmGfRHTuur8IVYVAfesZonHwZFSQ
   :provisioning_wizard: interactive

--- a/config/fusor-scenario.template
+++ b/config/fusor-scenario.template
@@ -1,10 +1,10 @@
---- 
+---
   :name: "Fusor"
   :description: ""
   :enabled: true
   :log_dir: "/var/log/foreman-installer"
   :log_name: "foreman-installer.log"
-  :log_level: "INFO"
+  :log_level: "DEBUG"
   :no_prefix: false
   :mapping:
     :"foreman::plugin::fusor":
@@ -140,7 +140,7 @@
     - /usr/share/katello-installer-base/hooks
   :custom: {}
   :low_priority_modules: []
-  :verbose_log_level: info
+  :verbose_log_level: debug
   :parser_cache_path: "./config/parser_cache.json"
   :provisioning_wizard: interactive
   :order:

--- a/hooks/pre_validations/10-gather_and_set_fusor_values.rb
+++ b/hooks/pre_validations/10-gather_and_set_fusor_values.rb
@@ -223,7 +223,6 @@ if app_value(:provisioning_wizard) != 'none'
 
   d=YAML::load(File.open('/etc/fusor-installer/fusor-scenario.template'))
   if app_value(:devel_env)
-    d[:log_level] = 'DEBUG'
     d[:hook_dirs] = []
     d[:order] = ['certs', 'katello_devel', 'foreman_proxy', 'capsule']
   end


### PR DESCRIPTION
Showing of debug-level messages in `/var/log/foreman-installer/foreman-installer.log` is desired to match the convention set by Satellite 6.