### PR TITLE
update the if[] parameter check with double brackets

### DIFF
--- a/bin/fusor-installer
+++ b/bin/fusor-installer
@@ -223,7 +223,7 @@ print_with_outcome() {
   fi
 }
 
-if [ $@ == "--upgrade" ]; then
+if [[ "$@" == "--upgrade" ]]; then
   ${FUSOR_LIBEXEC_DIR}/fusor-upgrade-qci
 else
   fusor_install "$@"


### PR DESCRIPTION
when running the fusor-installer in the dev env, there is a "[: too many arguments" output.  The double brackets resolves this issues.  